### PR TITLE
fix: safe category/budget updates + reworked seed defaults

### DIFF
--- a/src/hooks/use-budgets.ts
+++ b/src/hooks/use-budgets.ts
@@ -1,8 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { sheetsClient } from '@/lib/sheets-client'
 import { queryKeys } from '@/lib/query-keys'
-import { parseBudgetRow, serializeBudget, serializeBudgetUpdate } from '@/lib/transformers'
-import type { Budget, BudgetFormData, BudgetPeriodType, Category } from '@/types'
+import { parseBudgetRow, serializeBudget } from '@/lib/transformers'
+import type { Budget, BudgetFormData, BudgetPeriodType, BudgetRow, Category } from '@/types'
 
 export function useBudgets() {
   return useQuery({
@@ -32,9 +32,15 @@ export function useUpsertBudget() {
         const serialized = serializeBudget(data)
         await sheetsClient.budgets().createRow(serialized)
       } else {
-        await sheetsClient
-          .budgets()
-          .updateRow(rowIndex + 2, serializeBudgetUpdate({ amount: data.amount }))
+        // The sheets-db-api's updateRow endpoint is PUT-semantic: any column
+        // not included in the payload gets blanked. Merge the new amount into
+        // the existing row so category_id/period_type/period_key survive.
+        const merged: BudgetRow = {
+          ...rows[rowIndex],
+          amount: String(data.amount),
+          updated_at: new Date().toISOString(),
+        }
+        await sheetsClient.budgets().updateRow(rowIndex + 2, merged)
       }
     },
     onSuccess: () => {

--- a/src/hooks/use-categories.ts
+++ b/src/hooks/use-categories.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { sheetsClient } from '@/lib/sheets-client'
 import { queryKeys } from '@/lib/query-keys'
-import { parseCategoryRow, serializeCategory, serializeCategoryUpdate } from '@/lib/transformers'
+import { parseCategoryRow, serializeCategory } from '@/lib/transformers'
 import type { Category, CategoryFormData, CategoryRow, CategoryType } from '@/types'
 
 export function useCategories() {
@@ -42,6 +42,28 @@ export function useCreateCategory() {
   })
 }
 
+// The sheets-db-api's updateRow endpoint is PUT-semantic: fields not in the
+// payload get blanked. Always merge partial updates into the full existing row
+// before sending so columns like is_active, name, type, etc. are preserved.
+function mergeCategoryUpdate(
+  existing: CategoryRow,
+  patch: Partial<CategoryFormData>
+): CategoryRow {
+  const merged: CategoryRow = { ...existing }
+  if (patch.name !== undefined) merged.name = patch.name
+  if (patch.type !== undefined) merged.type = patch.type
+  if (patch.icon !== undefined) merged.icon = patch.icon
+  if (patch.color !== undefined) merged.color = patch.color
+  if (patch.budget_amount !== undefined) {
+    merged.budget_amount = patch.budget_amount !== null ? String(patch.budget_amount) : ''
+  }
+  if (patch.budget_cadence !== undefined) {
+    merged.budget_cadence = patch.budget_cadence ?? ''
+  }
+  merged.updated_at = new Date().toISOString()
+  return merged
+}
+
 export function useUpdateCategory() {
   const queryClient = useQueryClient()
 
@@ -59,8 +81,8 @@ export function useUpdateCategory() {
         throw new Error('Category not found')
       }
 
-      const updateData = serializeCategoryUpdate(data)
-      await sheetsClient.categories().updateRow(rowIndex + 2, updateData)
+      const merged = mergeCategoryUpdate(rows[rowIndex], data)
+      await sheetsClient.categories().updateRow(rowIndex + 2, merged)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.categories.all })
@@ -79,10 +101,12 @@ export function useDeleteCategory() {
         throw new Error('Category not found')
       }
 
-      await sheetsClient.categories().updateRow(rowIndex + 2, {
+      const merged: CategoryRow = {
+        ...rows[rowIndex],
         is_active: 'false',
         updated_at: new Date().toISOString(),
-      } as Partial<CategoryRow>)
+      }
+      await sheetsClient.categories().updateRow(rowIndex + 2, merged)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.categories.all })

--- a/src/hooks/use-categories.ts
+++ b/src/hooks/use-categories.ts
@@ -90,6 +90,38 @@ export function useUpdateCategory() {
   })
 }
 
+// Applies multiple category patches in a single sheets-db-api bulk call.
+// Fetches the existing rows once, merges each patch into its full row
+// (same PUT-safe logic as single-update), and issues one updateRowsBulk.
+// Avoids the N x (getRows + updateRow) fan-out that trips Google Sheets
+// read-quota limits when used for Seed Defaults etc.
+export function useBulkUpdateCategories() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (
+      patches: Array<{ id: string; data: Partial<CategoryFormData> }>
+    ) => {
+      if (patches.length === 0) return
+      const rows = await sheetsClient.categories().getRows()
+      const updates: Array<{ rowIndex: number; data: CategoryRow }> = []
+      for (const { id, data } of patches) {
+        const rowIndex = rows.findIndex((r) => r.id === id)
+        if (rowIndex === -1) continue
+        updates.push({
+          rowIndex: rowIndex + 2,
+          data: mergeCategoryUpdate(rows[rowIndex], data),
+        })
+      }
+      if (updates.length === 0) return
+      await sheetsClient.categories().updateRowsBulk(updates)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.categories.all })
+    },
+  })
+}
+
 export function useDeleteCategory() {
   const queryClient = useQueryClient()
 

--- a/src/lib/sheets-client.ts
+++ b/src/lib/sheets-client.ts
@@ -174,6 +174,8 @@ class SheetsClient {
       updateRow: (rowIndex: number, data: Partial<CategoryRow>) =>
         this.updateRow(SHEET_NAMES.CATEGORIES, rowIndex, data as unknown as Record<string, string>),
       deleteRow: (rowIndex: number) => this.deleteRow(SHEET_NAMES.CATEGORIES, rowIndex),
+      updateRowsBulk: (updates: Array<{ rowIndex: number; data: Partial<CategoryRow> }>) =>
+        this.updateRowsBulk(SHEET_NAMES.CATEGORIES, updates as unknown as Array<{ rowIndex: number; data: Record<string, string> }>),
     }
   }
 

--- a/src/pages/budgets.tsx
+++ b/src/pages/budgets.tsx
@@ -21,7 +21,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { useCategories, useUpdateCategory } from '@/hooks/use-categories'
+import {
+  useBulkUpdateCategories,
+  useCategories,
+  useUpdateCategory,
+} from '@/hooks/use-categories'
 import { useTransactions } from '@/hooks/use-transactions'
 import {
   useBudgets,
@@ -56,6 +60,7 @@ export function BudgetsPage() {
   const { data: budgetsData } = useBudgets()
   const { data: transactionsData } = useTransactions()
   const updateCategory = useUpdateCategory()
+  const bulkUpdateCategories = useBulkUpdateCategories()
   const upsertBudget = useUpsertBudget()
   const deleteBudget = useDeleteBudget()
 
@@ -142,23 +147,31 @@ export function BudgetsPage() {
   }, [seedDialogOpen, expenseCategories, transactions, activeTab])
 
   const applySeeds = async () => {
-    for (const { category, proposed } of seedProposals) {
-      try {
-        await updateCategory.mutateAsync({
+    if (seedProposals.length === 0) {
+      setSeedDialogOpen(false)
+      return
+    }
+    try {
+      await bulkUpdateCategories.mutateAsync(
+        seedProposals.map(({ category, proposed }) => ({
           id: category.id,
           data: { budget_amount: proposed, budget_cadence: activeTab },
-        })
-      } catch {
-        // per-category failure silently skipped; user will see it didn't move
-      }
+        }))
+      )
+      toast({
+        title: 'Seeded defaults',
+        description: `Applied ${activeTab} defaults to ${seedProposals.length} ${
+          seedProposals.length === 1 ? 'category' : 'categories'
+        }.`,
+        variant: 'success',
+      })
+    } catch (error) {
+      toast({
+        title: 'Error',
+        description: error instanceof Error ? error.message : 'Failed to seed defaults',
+        variant: 'destructive',
+      })
     }
-    toast({
-      title: 'Seeded defaults',
-      description: `Applied ${activeTab} defaults to ${seedProposals.length} ${
-        seedProposals.length === 1 ? 'category' : 'categories'
-      }.`,
-      variant: 'success',
-    })
     setSeedDialogOpen(false)
   }
 

--- a/src/pages/budgets.tsx
+++ b/src/pages/budgets.tsx
@@ -118,10 +118,11 @@ export function BudgetsPage() {
       targetMonths.push(`${y}-${String(m).padStart(2, '0')}`)
     }
 
-    return tabCategories
-      .filter((c) => !c.budget_amount)
+    // Propose for every expense category with spending history.
+    // Seed sets both cadence (to active tab) and amount — overwriting existing
+    // values so the user can fully re-seed.
+    return expenseCategories
       .map((category) => {
-        // Sum expense transactions per targeted month for this category
         const perMonthTotals = targetMonths.map((mKey) =>
           transactions
             .filter(
@@ -138,22 +139,24 @@ export function BudgetsPage() {
         return { category, proposed }
       })
       .filter((p) => p.proposed > 0)
-  }, [seedDialogOpen, tabCategories, transactions, activeTab])
+  }, [seedDialogOpen, expenseCategories, transactions, activeTab])
 
   const applySeeds = async () => {
     for (const { category, proposed } of seedProposals) {
       try {
         await updateCategory.mutateAsync({
           id: category.id,
-          data: { budget_amount: proposed },
+          data: { budget_amount: proposed, budget_cadence: activeTab },
         })
       } catch {
-        // toast handled below in catch-all
+        // per-category failure silently skipped; user will see it didn't move
       }
     }
     toast({
-      title: 'Defaults seeded',
-      description: `Set default for ${seedProposals.length} categories.`,
+      title: 'Seeded defaults',
+      description: `Applied ${activeTab} defaults to ${seedProposals.length} ${
+        seedProposals.length === 1 ? 'category' : 'categories'
+      }.`,
       variant: 'success',
     })
     setSeedDialogOpen(false)
@@ -411,33 +414,54 @@ export function BudgetsPage() {
       <AlertDialog open={seedDialogOpen} onOpenChange={setSeedDialogOpen}>
         <AlertDialogContent className="max-h-[80vh] overflow-y-auto">
           <AlertDialogHeader>
-            <AlertDialogTitle>Seed defaults from trailing 6-mo median</AlertDialogTitle>
+            <AlertDialogTitle>
+              Seed {activeTab} defaults from trailing 6-mo median
+            </AlertDialogTitle>
             <AlertDialogDescription>
-              Propose default {activeTab} budgets for categories that don&apos;t have one yet,
-              based on the median of the last 6 complete months of spending. One-off months
-              are de-weighted by using median instead of mean.
+              Sets both cadence and default amount for every expense category
+              with spending history, based on the median of the last 6 complete
+              months. Existing defaults and cadences will be{' '}
+              <span className="font-medium text-foreground">overwritten</span>.
+              One-off months are de-weighted by using the median instead of the mean.
+              Per-month / per-year overrides are not touched.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <div className="space-y-2 py-2">
             {seedProposals.length === 0 ? (
               <p className="text-sm text-muted-foreground">
-                No categories need defaults — every {activeTab} category already has one set.
+                No spending history yet — nothing to seed from.
               </p>
             ) : (
-              seedProposals.map(({ category, proposed }) => (
-                <div key={category.id} className="flex items-center justify-between text-sm">
-                  <div className="flex items-center gap-2">
-                    <span>{category.icon}</span>
-                    <span>{category.name}</span>
+              seedProposals.map(({ category, proposed }) => {
+                const currentCadenceMatches = category.budget_cadence === activeTab
+                const currentAmount = category.budget_amount
+                const willChange =
+                  !currentCadenceMatches || currentAmount !== proposed
+                return (
+                  <div
+                    key={category.id}
+                    className="flex items-center justify-between text-sm"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span>{category.icon}</span>
+                      <span>{category.name}</span>
+                    </div>
+                    <div className="text-right text-xs">
+                      {willChange && currentAmount && currentCadenceMatches ? (
+                        <span className="text-muted-foreground line-through mr-2">
+                          {formatCurrency(currentAmount)}
+                        </span>
+                      ) : null}
+                      <span className="font-medium text-sm">
+                        {formatCurrency(proposed)}
+                      </span>
+                      <span className="text-muted-foreground text-xs">
+                        {activeTab === 'monthly' ? ' /mo' : ' /yr'}
+                      </span>
+                    </div>
                   </div>
-                  <span className="font-medium">
-                    {formatCurrency(proposed)}
-                    <span className="text-muted-foreground text-xs">
-                      {activeTab === 'monthly' ? ' /mo' : ' /yr'}
-                    </span>
-                  </span>
-                </div>
-              ))
+                )
+              })
             )}
           </div>
           <AlertDialogFooter>
@@ -446,7 +470,9 @@ export function BudgetsPage() {
               onClick={applySeeds}
               disabled={seedProposals.length === 0}
             >
-              Apply {seedProposals.length > 0 ? `to ${seedProposals.length}` : ''}
+              {seedProposals.length === 0
+                ? 'Apply'
+                : `Apply to ${seedProposals.length}`}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>


### PR DESCRIPTION
## Summary

Fixes a data-corruption bug in the monthly-budgets feature and reworks the Seed Defaults UX per follow-up feedback on #14.

### Bug: PUT-semantic updates wiped category fields

The sheets-db-api's `PUT /sheets/<Sheet>/rows/<idx>` endpoint replaces the entire row — any column not in the payload is blanked. The previous `useUpdateCategory` / `useDeleteCategory` / `useUpsertBudget` paths sent only the *changed* fields. That worked fine when the caller was the Category form (which always sent every field), but broke when the new Budgets page called with `{budget_cadence: 'monthly'}` alone. Result: `id`, `is_active`, `name`, `type`, `icon`, `color`, `created_at` all got blanked, and `useCategories` filtered the row out as inactive — the category "disappeared" from the UI.

Fix: every update path now fetches the existing row and merges the patch into a full row payload before sending. Works the same against PATCH or PUT servers.

**Live-sheet damage (22 of 23 category UUIDs lost) was restored separately before this PR.**

### UX: Seed Defaults was under-scoped

Matt's report: "I was unsure how to seed the default budget amounts. The button was never enabled." The old dialog only proposed for categories that matched the active tab's cadence AND had no default — which was almost always the empty intersection.

Reworked so that on the Monthly tab, Seed Defaults proposes trailing-6-mo-median amounts for *every* expense category with spending history, and Apply sets both cadence (to `monthly`) AND amount — overwriting existing values. Annual tab does the same with `12 × median`. The dialog now shows strikethrough on values that will be replaced so the overwrite is explicit.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `npm run lint` passes (0 warnings, 0 errors)
- [x] `npm run build` passes
- [x] All 8 Playwright smoke tests pass locally
- [ ] Manual QA: Budgets page → click "Make monthly" on an unbudgeted category, confirm the category stays visible (bug regression)
- [ ] Manual QA: Budgets page → Seed Defaults → Apply → check that cadences + amounts are set and overwrite existing defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)