### PR TITLE
feat(transactions): text search + sort by amount

### DIFF
--- a/src/components/transactions/transaction-filters.tsx
+++ b/src/components/transactions/transaction-filters.tsx
@@ -9,8 +9,14 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Card, CardContent } from '@/components/ui/card'
-import { X } from 'lucide-react'
+import { Search, X } from 'lucide-react'
 import type { Account, Category } from '@/types'
+
+export type TransactionSortBy =
+  | 'date_desc'
+  | 'date_asc'
+  | 'amount_desc'
+  | 'amount_asc'
 
 export interface TransactionFilterValues {
   dateFrom: string
@@ -18,6 +24,8 @@ export interface TransactionFilterValues {
   accountId: string
   categoryId: string
   type: string
+  searchText: string
+  sortBy: TransactionSortBy
 }
 
 interface TransactionFiltersProps {
@@ -27,12 +35,16 @@ interface TransactionFiltersProps {
   categories: Category[]
 }
 
+const DEFAULT_SORT: TransactionSortBy = 'date_desc'
+
 const EMPTY_FILTERS: TransactionFilterValues = {
   dateFrom: '',
   dateTo: '',
   accountId: '',
   categoryId: '',
   type: '',
+  searchText: '',
+  sortBy: DEFAULT_SORT,
 }
 
 export function TransactionFilters({
@@ -41,9 +53,19 @@ export function TransactionFilters({
   accounts,
   categories,
 }: TransactionFiltersProps) {
-  const hasActiveFilters = Object.values(filters).some((v) => v !== '')
+  const hasActiveFilters =
+    filters.dateFrom !== '' ||
+    filters.dateTo !== '' ||
+    filters.accountId !== '' ||
+    filters.categoryId !== '' ||
+    filters.type !== '' ||
+    filters.searchText !== '' ||
+    filters.sortBy !== DEFAULT_SORT
 
-  const updateFilter = (key: keyof TransactionFilterValues, value: string) => {
+  const updateFilter = <K extends keyof TransactionFilterValues>(
+    key: K,
+    value: TransactionFilterValues[K]
+  ) => {
     onFiltersChange({ ...filters, [key]: value })
   }
 
@@ -53,7 +75,20 @@ export function TransactionFilters({
 
   return (
     <Card>
-      <CardContent className="pt-4">
+      <CardContent className="pt-4 space-y-3">
+        {/* Search row */}
+        <div className="relative">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            id="searchText"
+            type="search"
+            value={filters.searchText}
+            onChange={(e) => updateFilter('searchText', e.target.value)}
+            placeholder="Search description, notes, category..."
+            className="pl-8 h-9"
+          />
+        </div>
+
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
           {/* Date From */}
           <div className="space-y-1">
@@ -140,6 +175,25 @@ export function TransactionFilters({
                 <SelectItem value="income">Income</SelectItem>
                 <SelectItem value="expense">Expense</SelectItem>
                 <SelectItem value="transfer">Transfer</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Sort */}
+          <div className="space-y-1">
+            <Label className="text-xs">Sort</Label>
+            <Select
+              value={filters.sortBy}
+              onValueChange={(value) => updateFilter('sortBy', value as TransactionSortBy)}
+            >
+              <SelectTrigger className="h-9">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="date_desc">Date (newest)</SelectItem>
+                <SelectItem value="date_asc">Date (oldest)</SelectItem>
+                <SelectItem value="amount_desc">Amount (high to low)</SelectItem>
+                <SelectItem value="amount_asc">Amount (low to high)</SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/src/components/transactions/transaction-list.tsx
+++ b/src/components/transactions/transaction-list.tsx
@@ -38,6 +38,11 @@ interface TransactionListProps {
   accounts: Account[]
   onEdit?: (transaction: Transaction) => void
   onDelete?: (transaction: Transaction) => void
+  // When true (default), transactions are rendered in date-grouped sections
+  // with their incoming order preserved within each date. When false, the list
+  // renders flat in the exact order passed in — used when the caller is
+  // sorting by amount etc. where the date grouping would hide the sort.
+  groupByDate?: boolean
 }
 
 export function TransactionList({
@@ -46,6 +51,7 @@ export function TransactionList({
   accounts,
   onEdit,
   onDelete,
+  groupByDate = true,
 }: TransactionListProps) {
   const { toast } = useToast()
   const { mutate: categorizeTransactions, isPending: isCategorizing } = useCategorizeTransactions()
@@ -100,20 +106,19 @@ export function TransactionList({
     )
   }
 
-  // Group transactions by date
-  const grouped = transactions.reduce(
-    (acc, transaction) => {
-      const date = transaction.date
-      if (!acc[date]) {
-        acc[date] = []
-      }
-      acc[date].push(transaction)
-      return acc
-    },
-    {} as Record<string, Transaction[]>
-  )
-
-  const sortedDates = Object.keys(grouped).sort((a, b) => b.localeCompare(a))
+  // Group transactions by date. Preserve the order the dates appear in the
+  // incoming list so the caller's sort direction (date asc vs desc) is
+  // respected — we used to hard-code desc here, which broke ascending sorts.
+  const grouped: Record<string, Transaction[]> = {}
+  const sortedDates: string[] = []
+  for (const transaction of transactions) {
+    const date = transaction.date
+    if (!grouped[date]) {
+      grouped[date] = []
+      sortedDates.push(date)
+    }
+    grouped[date].push(transaction)
+  }
 
   return (
     <div className="space-y-6">
@@ -140,25 +145,40 @@ export function TransactionList({
           </Button>
         </div>
       )}
-      {sortedDates.map((date) => (
-        <div key={date}>
-          <h3 className="text-sm font-medium text-muted-foreground mb-2">
-            {formatDateHeader(date)}
-          </h3>
-          <div className="space-y-2">
-            {grouped[date].map((transaction) => (
-              <TransactionItem
-                key={transaction.id}
-                transaction={transaction}
-                category={categories.find((c) => c.id === transaction.category_id)}
-                account={accounts.find((a) => a.id === transaction.source_account_id)}
-                onEdit={onEdit}
-                onDelete={onDelete}
-              />
-            ))}
+      {groupByDate ? (
+        sortedDates.map((date) => (
+          <div key={date}>
+            <h3 className="text-sm font-medium text-muted-foreground mb-2">
+              {formatDateHeader(date)}
+            </h3>
+            <div className="space-y-2">
+              {grouped[date].map((transaction) => (
+                <TransactionItem
+                  key={transaction.id}
+                  transaction={transaction}
+                  category={categories.find((c) => c.id === transaction.category_id)}
+                  account={accounts.find((a) => a.id === transaction.source_account_id)}
+                  onEdit={onEdit}
+                  onDelete={onDelete}
+                />
+              ))}
+            </div>
           </div>
+        ))
+      ) : (
+        <div className="space-y-2">
+          {transactions.map((transaction) => (
+            <TransactionItem
+              key={transaction.id}
+              transaction={transaction}
+              category={categories.find((c) => c.id === transaction.category_id)}
+              account={accounts.find((a) => a.id === transaction.source_account_id)}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
+          ))}
         </div>
-      ))}
+      )}
     </div>
   )
 }

--- a/src/pages/transactions.tsx
+++ b/src/pages/transactions.tsx
@@ -28,29 +28,51 @@ export function TransactionsPage() {
   const [editingTransaction, setEditingTransaction] = useState<Transaction | undefined>()
   const [filters, setFilters] = useState<TransactionFilterValues>(EMPTY_FILTERS)
 
-  // Filter transactions based on current filter values
+  // Filter + sort transactions based on current filter values
   const filteredTransactions = useMemo(() => {
     if (!transactions) return []
 
-    return transactions.filter((t) => {
-      // Date from filter
+    const needle = filters.searchText.trim().toLowerCase()
+    const categoryById = new Map((categories ?? []).map((c) => [c.id, c]))
+
+    const result = transactions.filter((t) => {
       if (filters.dateFrom && t.date < filters.dateFrom) return false
-
-      // Date to filter
       if (filters.dateTo && t.date > filters.dateTo) return false
-
-      // Account filter
       if (filters.accountId && t.source_account_id !== filters.accountId) return false
-
-      // Category filter
       if (filters.categoryId && t.category_id !== filters.categoryId) return false
-
-      // Type filter
       if (filters.type && t.type !== filters.type) return false
+
+      if (needle) {
+        const cat = t.category_id ? categoryById.get(t.category_id) : undefined
+        const haystack = [
+          t.description,
+          t.notes,
+          cat?.name,
+        ]
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase()
+        if (!haystack.includes(needle)) return false
+      }
 
       return true
     })
-  }, [transactions, filters])
+
+    const cmp = (a: Transaction, b: Transaction) => {
+      switch (filters.sortBy) {
+        case 'date_asc':
+          return a.date.localeCompare(b.date)
+        case 'amount_desc':
+          return Math.abs(b.amount) - Math.abs(a.amount)
+        case 'amount_asc':
+          return Math.abs(a.amount) - Math.abs(b.amount)
+        case 'date_desc':
+        default:
+          return b.date.localeCompare(a.date)
+      }
+    }
+    return result.slice().sort(cmp)
+  }, [transactions, categories, filters])
 
   const handleEdit = (transaction: Transaction) => {
     setEditingTransaction(transaction)
@@ -140,6 +162,7 @@ export function TransactionsPage() {
           accounts={accounts ?? []}
           onEdit={handleEdit}
           onDelete={handleDelete}
+          groupByDate={filters.sortBy === 'date_desc' || filters.sortBy === 'date_asc'}
         />
       )}
 


### PR DESCRIPTION
Closes #19.

## Summary

- **Text search** in the transactions filter bar: substring match (case-insensitive) across description, notes, and category name. Immediate — no debounce; filtering 3k rows client-side is trivially fast and debouncing just added input lag.
- **Sort control**: Date (newest / oldest) and Amount (high→low / low→high). Amount uses `Math.abs` so income and expenses mix by size regardless of sign. Default = newest first (no regression).
- `TransactionList` gained a `groupByDate` prop (defaults to `true`). Page passes `false` when sorting by amount so the date grouping doesn't mask the sort. Internal date ordering now follows caller's incoming order instead of hard-coding desc, so `date_asc` actually renders oldest-first.
- Clear Filters resets `searchText` + `sortBy` along with existing fields. "Active filter" detection now counts both.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run build` passes
- [x] All 8 Playwright smoke tests pass
- [ ] Manual: type "Costco" — only rows with Costco in description/notes/category remain
- [ ] Manual: switch to Amount (high to low) — list renders flat (no date headers) in descending magnitude

🤖 Generated with [Claude Code](https://claude.com/claude-code)