### PR TITLE
feat(dashboard): monthly income + net in Budget Overview

### DIFF
--- a/src/components/dashboard/budget-overview.tsx
+++ b/src/components/dashboard/budget-overview.tsx
@@ -106,7 +106,25 @@ export function BudgetOverview({
     return { spent, budget, projected }
   }, [rows])
 
-  if (rows.length === 0) {
+  // Month-level cashflow: income vs all expenses (not just budgeted ones)
+  // for the selected month. Transfers are excluded so there's no
+  // double-counting. Net = income - expenses.
+  const monthCashflow = useMemo(() => {
+    const prefix = yearMonth
+    let income = 0
+    let expenses = 0
+    for (const t of transactions) {
+      if (!t.date.startsWith(prefix)) continue
+      if (t.type === 'income') income += t.amount
+      else if (t.type === 'expense') expenses += Math.abs(t.amount)
+    }
+    return { income, expenses, net: income - expenses }
+  }, [transactions, yearMonth])
+
+  const hasAnyActivity =
+    monthCashflow.income !== 0 || monthCashflow.expenses !== 0 || rows.length > 0
+
+  if (!hasAnyActivity) {
     return (
       <Card>
         <CardHeader>
@@ -114,7 +132,7 @@ export function BudgetOverview({
         </CardHeader>
         <CardContent>
           <p className="text-sm text-muted-foreground text-center py-4">
-            No budgets set. Visit the Budget page to set monthly or annual budgets for categories.
+            No budgets or transactions in this period yet. Visit the Budget page to set monthly or annual budgets.
           </p>
         </CardContent>
       </Card>
@@ -127,6 +145,37 @@ export function BudgetOverview({
         <CardTitle className="text-base">Budget Overview</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
+        {/* Monthly cashflow — income, expenses, net */}
+        <div className="grid grid-cols-3 gap-2 pb-3 border-b">
+          <div>
+            <div className="text-xs text-muted-foreground">Income</div>
+            <div className="text-base font-semibold text-green-600">
+              {formatCurrency(monthCashflow.income)}
+            </div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">Expenses</div>
+            <div className="text-base font-semibold text-red-600">
+              {formatCurrency(monthCashflow.expenses)}
+            </div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">Net</div>
+            <div
+              className={`text-base font-semibold ${
+                monthCashflow.net > 0
+                  ? 'text-green-600'
+                  : monthCashflow.net < 0
+                    ? 'text-red-600'
+                    : 'text-muted-foreground'
+              }`}
+            >
+              {monthCashflow.net >= 0 ? '+' : ''}
+              {formatCurrency(monthCashflow.net)}
+            </div>
+          </div>
+        </div>
+
         {totals && (
           <div className="space-y-2 pb-3 border-b">
             <div className="flex items-baseline justify-between">


### PR DESCRIPTION
Closes #20.

## Summary

Adds a 3-column cashflow strip at the top of the Budget Overview card: **Income**, **Expenses**, **Net** — all for the selected month. Transfers are excluded so nothing double-counts. Net is color-coded (green positive, red negative, muted zero). Budget progress rows below are unchanged.

Implementation note on the open questions in the issue:

- **Q2 (YTD income on annual tab)**: The dashboard's BudgetOverview doesn't have a monthly/annual tab — the per-category cadence only lives on the Budgets page. The dashboard's period picker is month-based, so this strip reports *this month*. If you later want a YTD view, we'd add a period-type toggle to the dashboard; filing a separate follow-up would be cleaner than shoehorning here.
- Income/Expenses in the strip are computed across **all** transactions in the month (not just budgeted categories) — this gives the most honest "did I save money?" number. The budget-progress rows below continue to reflect only categories with budgets.

## Test plan

- [x] `tsc --noEmit`, `lint`, `build` all pass
- [x] All 8 Playwright smoke tests pass
- [ ] Manual: dashboard cashflow strip renders for the selected month; switching the month updates all three numbers
- [ ] Manual: with no budgets and no transactions, card shows the neutral "no activity" message; with only transactions and no budgets, strip renders but no per-category bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)