### PR TITLE
feat(dashboard): layout B — two-column hero, drop filler

### DIFF
--- a/src/components/dashboard/income-expense-chart.tsx
+++ b/src/components/dashboard/income-expense-chart.tsx
@@ -62,12 +62,12 @@ export function IncomeExpenseChart({ transactions }: IncomeExpenseChartProps) {
 
   if (data.length === 0) {
     return (
-      <Card>
+      <Card className="flex flex-col h-full">
         <CardHeader>
           <CardTitle className="text-base">Cashflow</CardTitle>
         </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground text-center py-8">
+        <CardContent className="flex-1 flex items-center justify-center">
+          <p className="text-sm text-muted-foreground text-center">
             No transaction data to display
           </p>
         </CardContent>
@@ -76,12 +76,12 @@ export function IncomeExpenseChart({ transactions }: IncomeExpenseChartProps) {
   }
 
   return (
-    <Card>
+    <Card className="flex flex-col h-full">
       <CardHeader>
-        <CardTitle className="text-base">Income vs Expenses</CardTitle>
+        <CardTitle className="text-base">Cashflow</CardTitle>
       </CardHeader>
-      <CardContent>
-        <div className="h-64">
+      <CardContent className="flex-1 flex flex-col">
+        <div className="flex-1 min-h-[16rem]">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={data}>
               <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,8 +1,5 @@
 import { useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
 import { PageHeader } from '@/components/layout/page-header'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
 import { ErrorState } from '@/components/ui/error-state'
 import {
   Select,
@@ -11,21 +8,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { TransactionItem } from '@/components/transactions/transaction-item'
 import {
   SpendingByCategory,
   IncomeExpenseChart,
   BudgetOverview,
   ChartCardSkeleton,
   BudgetOverviewSkeleton,
-  RecentTransactionsSkeleton,
-  StatCardsSkeleton,
 } from '@/components/dashboard'
-import { useTransactions, useRecentTransactions, useMonthlyTotals } from '@/hooks/use-transactions'
+import { useTransactions } from '@/hooks/use-transactions'
 import { useCategories } from '@/hooks/use-categories'
 import { useBudgets } from '@/hooks/use-budgets'
-import { formatCurrency, getCurrentMonth } from '@/lib/utils'
-import { ArrowRight, TrendingUp, TrendingDown } from 'lucide-react'
+import { getCurrentMonth } from '@/lib/utils'
 
 function formatMonthLabel(yearMonth: string): string {
   const [yearStr, monthStr] = yearMonth.split('-')
@@ -34,14 +27,12 @@ function formatMonthLabel(yearMonth: string): string {
 }
 
 export function DashboardPage() {
-  const { income, expenses } = useMonthlyTotals()
   const {
     data: allTransactions,
     isLoading: transactionsLoading,
     error: transactionsError,
     refetch: refetchTransactions,
   } = useTransactions()
-  const { data: recentTransactions, isLoading: recentLoading } = useRecentTransactions(5)
   const { data: categories } = useCategories()
   const { data: budgets } = useBudgets()
 
@@ -76,9 +67,46 @@ export function DashboardPage() {
 
   return (
     <div className="space-y-6">
-      <PageHeader title="Dashboard" />
+      <PageHeader
+        title="Dashboard"
+        action={
+          <Select value={yearMonth} onValueChange={setYearMonth}>
+            <SelectTrigger className="w-[180px] h-8 text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {monthOptions.map((ym) => (
+                <SelectItem key={ym} value={ym}>
+                  {formatMonthLabel(ym)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        }
+      />
 
-      {/* Spending Categories Bar Chart */}
+      {/* Hero row: Budget Overview + Cashflow chart side-by-side on lg+,
+          stacked on mobile/tablet. Answers "did I meet budget?" and
+          "am I trending positive?" at-a-glance. */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {transactionsLoading ? (
+          <BudgetOverviewSkeleton />
+        ) : (
+          <BudgetOverview
+            transactions={allTransactions ?? []}
+            categories={categories ?? []}
+            budgets={budgets ?? []}
+            yearMonth={yearMonth}
+          />
+        )}
+        {transactionsLoading ? (
+          <ChartCardSkeleton height="h-64" />
+        ) : (
+          <IncomeExpenseChart transactions={allTransactions ?? []} />
+        )}
+      </div>
+
+      {/* Spending by Category — full width below the hero row. */}
       {transactionsLoading ? (
         <ChartCardSkeleton height="h-48" />
       ) : (
@@ -86,112 +114,6 @@ export function DashboardPage() {
           transactions={allTransactions ?? []}
           categories={categories ?? []}
         />
-      )}
-
-      {/* Budget Overview */}
-      {transactionsLoading ? (
-        <BudgetOverviewSkeleton />
-      ) : (
-        <div className="space-y-2">
-          <div className="flex items-center justify-end">
-            <Select value={yearMonth} onValueChange={setYearMonth}>
-              <SelectTrigger className="w-[180px] h-8 text-sm">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {monthOptions.map((ym) => (
-                  <SelectItem key={ym} value={ym}>
-                    {formatMonthLabel(ym)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <BudgetOverview
-            transactions={allTransactions ?? []}
-            categories={categories ?? []}
-            budgets={budgets ?? []}
-            yearMonth={yearMonth}
-          />
-        </div>
-      )}
-
-      {/* Cashflow chart */}
-      {transactionsLoading ? (
-        <ChartCardSkeleton height="h-64" />
-      ) : (
-        <IncomeExpenseChart transactions={allTransactions ?? []} />
-      )}
-
-      {/* Individual Income and Expenses by Month */}
-      {transactionsLoading ? (
-        <StatCardsSkeleton />
-      ) : (
-        <div className="grid grid-cols-2 gap-4">
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
-                <TrendingUp className="h-4 w-4 text-green-600" />
-                Income
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-xl font-bold text-green-600">
-                +{formatCurrency(income)}
-              </div>
-              <p className="text-xs text-muted-foreground">This month</p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
-                <TrendingDown className="h-4 w-4 text-red-600" />
-                Expenses
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-xl font-bold text-red-600">
-                -{formatCurrency(expenses)}
-              </div>
-              <p className="text-xs text-muted-foreground">This month</p>
-            </CardContent>
-          </Card>
-        </div>
-      )}
-
-      {/* Recent Transactions */}
-      {recentLoading ? (
-        <RecentTransactionsSkeleton />
-      ) : (
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle>Recent Transactions</CardTitle>
-            <Button variant="ghost" size="sm" asChild>
-              <Link to="/transactions" className="flex items-center gap-1">
-                View all
-                <ArrowRight className="h-4 w-4" />
-              </Link>
-            </Button>
-          </CardHeader>
-          <CardContent>
-            {recentTransactions && recentTransactions.length > 0 ? (
-              <div className="space-y-2">
-                {recentTransactions.map((transaction) => (
-                  <TransactionItem
-                    key={transaction.id}
-                    transaction={transaction}
-                    category={categories?.find((c) => c.id === transaction.category_id)}
-                  />
-                ))}
-              </div>
-            ) : (
-              <p className="text-sm text-muted-foreground text-center py-4">
-                No transactions yet. Add your first transaction to get started.
-              </p>
-            )}
-          </CardContent>
-        </Card>
       )}
     </div>
   )


### PR DESCRIPTION
Closes #22.

## Summary

Picked **layout B** after walking through your dashboard goals in chat:
- "Did I meet budget this month?" — Budget Overview answers this
- "Am I trending positive month-to-month?" — Cashflow chart with cumulative-net answers this

New shape:

```
Row 1 (lg+ side-by-side, mobile stacked):
  ┌─ Budget Overview ────────────┐  ┌─ Income vs Expenses chart ───┐
  │  income / spent / net         │  │  12mo, with cumulative net   │
  │  per-cat bars                 │  │                              │
  └──────────────────────────────┘  └──────────────────────────────┘

Row 2 (full width):
  ┌─ Spending by Category ─────────────────────────────────────────┐
  │  bar chart                                                       │
  └─────────────────────────────────────────────────────────────────┘
```

**Dropped** (per your confirm):
- Recent Transactions card — `/transactions` is where browsing happens
- Standalone Income / Expenses stat cards — their numbers duplicate the cashflow strip already in Budget Overview

**Promoted** the period selector from a thin row above Budget Overview into the PageHeader action slot, so it sits next to "Dashboard" and applies obviously to the period-scoped data below.

## Follow-up filed

- **#29** — "Outliers" widget (largest transactions + trend-breaking categories) — to address the third thing you mentioned (one-offs that break trends).

## Test plan

- [x] `tsc --noEmit`, `lint`, `build` clean
- [x] All 7 Playwright smoke tests pass
- [ ] Manual at desktop — Budget Overview + Cashflow side by side, Spending by Category full width
- [ ] Manual at mobile — single column stack, period selector visible in header

Screenshots in Telegram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)