### PR TITLE
feat(dashboard): Outliers widget — trend-breakers + largest transactions

### DIFF
--- a/src/components/dashboard/dashboard-skeletons.tsx
+++ b/src/components/dashboard/dashboard-skeletons.tsx
@@ -71,6 +71,36 @@ export function RecentTransactionsSkeleton() {
   )
 }
 
+export function OutliersSkeleton() {
+  return (
+    <Card className="flex flex-col h-full">
+      <CardHeader className="pb-2">
+        <Skeleton className="h-4 w-24" />
+      </CardHeader>
+      <CardContent className="flex-1 space-y-4">
+        <Skeleton className="h-3 w-28" />
+        {[0, 1, 2].map((i) => (
+          <div key={`tb-${i}`} className="flex items-center justify-between">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+        ))}
+        <Skeleton className="h-3 w-32 mt-4" />
+        {[0, 1, 2, 3].map((i) => (
+          <div key={`tx-${i}`} className="flex items-center gap-2">
+            <Skeleton className="h-6 w-6 rounded-full" />
+            <div className="flex-1 space-y-1">
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="h-3 w-20" />
+            </div>
+            <Skeleton className="h-4 w-16" />
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}
+
 export function StatCardsSkeleton() {
   return (
     <div className="grid grid-cols-2 gap-4">

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -1,9 +1,11 @@
 export { SpendingByCategory } from './spending-by-category'
 export { IncomeExpenseChart } from './income-expense-chart'
 export { BudgetOverview } from './budget-overview'
+export { Outliers } from './outliers'
 export {
   ChartCardSkeleton,
   BudgetOverviewSkeleton,
   RecentTransactionsSkeleton,
   StatCardsSkeleton,
+  OutliersSkeleton,
 } from './dashboard-skeletons'

--- a/src/components/dashboard/outliers.tsx
+++ b/src/components/dashboard/outliers.tsx
@@ -1,0 +1,211 @@
+import { useMemo } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { formatCurrency, formatDate } from '@/lib/utils'
+import type { Category, Transaction } from '@/types'
+
+interface OutliersProps {
+  transactions: Transaction[]
+  categories: Category[]
+  yearMonth: string  // YYYY-MM
+  topN?: number
+  trendBreakerRatio?: number  // How much above median = "breaking trend"
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid]
+}
+
+export function Outliers({
+  transactions,
+  categories,
+  yearMonth,
+  topN = 8,
+  trendBreakerRatio = 1.5,
+}: OutliersProps) {
+  const categoryById = useMemo(
+    () => new Map(categories.map((c) => [c.id, c])),
+    [categories]
+  )
+
+  // Top N single transactions for the selected period, ranked by abs(amount).
+  // Excludes transfers so intra-account moves don't dominate the list.
+  const topTransactions = useMemo(() => {
+    return transactions
+      .filter((t) => t.type !== 'transfer' && t.date.startsWith(yearMonth))
+      .slice()
+      .sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount))
+      .slice(0, topN)
+  }, [transactions, yearMonth, topN])
+
+  // Categories whose spend in the selected period is at least `ratio` × the
+  // trailing 6-month median for that category. Median (not mean) so a single
+  // big month in history doesn't mask today's anomaly.
+  const trendBreakers = useMemo(() => {
+    const [yearStr, monthStr] = yearMonth.split('-')
+    const year = Number(yearStr)
+    const month = Number(monthStr)
+
+    // Build list of the 6 full months preceding the selected period.
+    const pastMonths: string[] = []
+    for (let i = 1; i <= 6; i++) {
+      let y = year
+      let m = month - i
+      while (m <= 0) {
+        m += 12
+        y -= 1
+      }
+      pastMonths.push(`${y}-${String(m).padStart(2, '0')}`)
+    }
+
+    const expenseCats = categories.filter((c) => c.type === 'expense')
+    const rows: Array<{
+      category: Category
+      currentSpend: number
+      histMedian: number
+      ratio: number
+    }> = []
+
+    for (const category of expenseCats) {
+      const currentSpend = transactions
+        .filter(
+          (t) =>
+            t.type === 'expense' &&
+            t.category_id === category.id &&
+            t.date.startsWith(yearMonth)
+        )
+        .reduce((sum, t) => sum + Math.abs(t.amount), 0)
+
+      if (currentSpend <= 0) continue
+
+      const perMonth = pastMonths.map((m) =>
+        transactions
+          .filter(
+            (t) =>
+              t.type === 'expense' &&
+              t.category_id === category.id &&
+              t.date.startsWith(m)
+          )
+          .reduce((sum, t) => sum + Math.abs(t.amount), 0)
+      )
+      const histMedian = median(perMonth)
+      if (histMedian <= 0) continue
+
+      const ratio = currentSpend / histMedian
+      if (ratio >= trendBreakerRatio) {
+        rows.push({ category, currentSpend, histMedian, ratio })
+      }
+    }
+
+    return rows.sort((a, b) => b.ratio - a.ratio)
+  }, [transactions, categories, yearMonth, trendBreakerRatio])
+
+  const hasAnything = topTransactions.length > 0 || trendBreakers.length > 0
+
+  return (
+    <Card className="flex flex-col h-full">
+      <CardHeader>
+        <CardTitle className="text-base">Outliers</CardTitle>
+      </CardHeader>
+      <CardContent className="flex-1 space-y-4">
+        {!hasAnything && (
+          <p className="text-sm text-muted-foreground text-center py-4">
+            No transactions in this period yet.
+          </p>
+        )}
+
+        {trendBreakers.length > 0 && (
+          <div>
+            <h3 className="text-xs uppercase tracking-wide text-muted-foreground mb-2">
+              Trend-breakers
+            </h3>
+            <div className="space-y-1.5">
+              {trendBreakers.map(({ category, currentSpend, histMedian, ratio }) => (
+                <div
+                  key={category.id}
+                  className="flex items-center justify-between text-sm"
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span
+                      className="h-6 w-6 rounded-full flex items-center justify-center text-xs flex-shrink-0"
+                      style={{ backgroundColor: category.color + '20' }}
+                    >
+                      {category.icon}
+                    </span>
+                    <span className="font-medium truncate">{category.name}</span>
+                    <span className="text-xs text-red-500 font-medium whitespace-nowrap">
+                      {ratio.toFixed(1)}× typical
+                    </span>
+                  </div>
+                  <div className="text-right whitespace-nowrap">
+                    <span className="font-medium">{formatCurrency(currentSpend)}</span>
+                    <span className="text-muted-foreground text-xs">
+                      {' '}vs {formatCurrency(histMedian)}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {topTransactions.length > 0 && (
+          <div>
+            <h3 className="text-xs uppercase tracking-wide text-muted-foreground mb-2">
+              Largest this month
+            </h3>
+            <div className="space-y-1.5">
+              {topTransactions.map((t) => {
+                const cat = t.category_id ? categoryById.get(t.category_id) : undefined
+                const isExpense = t.amount < 0
+                return (
+                  <div
+                    key={t.id}
+                    className="flex items-center justify-between text-sm gap-2"
+                  >
+                    <div className="flex items-center gap-2 min-w-0">
+                      {cat ? (
+                        <span
+                          className="h-6 w-6 rounded-full flex items-center justify-center text-xs flex-shrink-0"
+                          style={{ backgroundColor: cat.color + '20' }}
+                        >
+                          {cat.icon}
+                        </span>
+                      ) : (
+                        <span className="h-6 w-6 rounded-full bg-secondary flex items-center justify-center text-xs flex-shrink-0">
+                          📝
+                        </span>
+                      )}
+                      <div className="min-w-0">
+                        <div className="font-medium truncate">{t.description}</div>
+                        <div className="text-xs text-muted-foreground truncate">
+                          {formatDate(t.date)}
+                          {cat && <span> · {cat.name}</span>}
+                          {!cat && <span> · Uncategorized</span>}
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className={
+                        isExpense
+                          ? 'amount-negative font-semibold whitespace-nowrap'
+                          : 'amount-positive font-semibold whitespace-nowrap'
+                      }
+                    >
+                      {isExpense ? '' : '+'}
+                      {formatCurrency(t.amount)}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/dashboard/spending-by-category.tsx
+++ b/src/components/dashboard/spending-by-category.tsx
@@ -39,12 +39,12 @@ export function SpendingByCategory({ transactions, categories }: SpendingByCateg
 
   if (data.length === 0) {
     return (
-      <Card>
+      <Card className="flex flex-col h-full">
         <CardHeader>
           <CardTitle className="text-base">Spending by Category</CardTitle>
         </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground text-center py-8">
+        <CardContent className="flex-1 flex items-center justify-center">
+          <p className="text-sm text-muted-foreground text-center">
             No expense data to display
           </p>
         </CardContent>
@@ -53,12 +53,12 @@ export function SpendingByCategory({ transactions, categories }: SpendingByCateg
   }
 
   return (
-    <Card>
+    <Card className="flex flex-col h-full">
       <CardHeader>
         <CardTitle className="text-base">Spending by Category</CardTitle>
       </CardHeader>
-      <CardContent>
-        <div className="h-64">
+      <CardContent className="flex-1 flex flex-col">
+        <div className="flex-1 min-h-[16rem]">
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={data} layout="vertical">
               <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />

--- a/src/components/dashboard/spending-by-category.tsx
+++ b/src/components/dashboard/spending-by-category.tsx
@@ -7,12 +7,22 @@ import type { Transaction, Category } from '@/types'
 interface SpendingByCategoryProps {
   transactions: Transaction[]
   categories: Category[]
+  /** Scope the chart to a single YYYY-MM period. Omit to show all-time. */
+  yearMonth?: string
 }
 
-export function SpendingByCategory({ transactions, categories }: SpendingByCategoryProps) {
+export function SpendingByCategory({
+  transactions,
+  categories,
+  yearMonth,
+}: SpendingByCategoryProps) {
   const data = useMemo(() => {
-    // Only include expenses
-    const expenses = transactions.filter((t) => t.type === 'expense')
+    // Only include expenses within the scoped period (if any)
+    const expenses = transactions.filter(
+      (t) =>
+        t.type === 'expense' &&
+        (yearMonth ? t.date.startsWith(yearMonth) : true)
+    )
 
     // Group by category
     const byCategory = expenses.reduce(
@@ -35,17 +45,21 @@ export function SpendingByCategory({ transactions, categories }: SpendingByCateg
         }
       })
       .sort((a, b) => b.value - a.value)
-  }, [transactions, categories])
+  }, [transactions, categories, yearMonth])
+
+  const title = 'Spending by Category'
 
   if (data.length === 0) {
     return (
       <Card className="flex flex-col h-full">
         <CardHeader>
-          <CardTitle className="text-base">Spending by Category</CardTitle>
+          <CardTitle className="text-base">{title}</CardTitle>
         </CardHeader>
         <CardContent className="flex-1 flex items-center justify-center">
           <p className="text-sm text-muted-foreground text-center">
-            No expense data to display
+            {yearMonth
+              ? 'No expenses in this period yet.'
+              : 'No expense data to display'}
           </p>
         </CardContent>
       </Card>
@@ -55,7 +69,7 @@ export function SpendingByCategory({ transactions, categories }: SpendingByCateg
   return (
     <Card className="flex flex-col h-full">
       <CardHeader>
-        <CardTitle className="text-base">Spending by Category</CardTitle>
+        <CardTitle className="text-base">{title}</CardTitle>
       </CardHeader>
       <CardContent className="flex-1 flex flex-col">
         <div className="flex-1 min-h-[16rem]">

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -116,6 +116,7 @@ export function DashboardPage() {
           <SpendingByCategory
             transactions={allTransactions ?? []}
             categories={categories ?? []}
+            yearMonth={yearMonth}
           />
         )}
         {transactionsLoading ? (

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -12,8 +12,10 @@ import {
   SpendingByCategory,
   IncomeExpenseChart,
   BudgetOverview,
+  Outliers,
   ChartCardSkeleton,
   BudgetOverviewSkeleton,
+  OutliersSkeleton,
 } from '@/components/dashboard'
 import { useTransactions } from '@/hooks/use-transactions'
 import { useCategories } from '@/hooks/use-categories'
@@ -106,15 +108,26 @@ export function DashboardPage() {
         )}
       </div>
 
-      {/* Spending by Category — full width below the hero row. */}
-      {transactionsLoading ? (
-        <ChartCardSkeleton height="h-48" />
-      ) : (
-        <SpendingByCategory
-          transactions={allTransactions ?? []}
-          categories={categories ?? []}
-        />
-      )}
+      {/* Detail row: Spending by Category + Outliers side-by-side on lg+. */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {transactionsLoading ? (
+          <ChartCardSkeleton height="h-48" />
+        ) : (
+          <SpendingByCategory
+            transactions={allTransactions ?? []}
+            categories={categories ?? []}
+          />
+        )}
+        {transactionsLoading ? (
+          <OutliersSkeleton />
+        ) : (
+          <Outliers
+            transactions={allTransactions ?? []}
+            categories={categories ?? []}
+            yearMonth={yearMonth}
+          />
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Closes #29.

## Summary

Third thing from your dashboard conversation: surfacing one-offs that break trends. New **Outliers** card on the dashboard, alongside Spending by Category in a second 2-column row on desktop.

Two sections inside:

**Trend-breakers** — categories where the selected period's expense spend is ≥ 1.5× the trailing 6-month *median* for that category. Median (not mean) so a single historical spike doesn't mask today's anomaly. Shows "1.8× typical" ratio + current vs historical.

**Largest this month** — top 8 single transactions in the selected period by `|amount|`, excluding transfers.

Both respect the Dashboard's period selector and update when you change months.

## Misc
- `SpendingByCategory` card got the same `flex flex-col h-full` + inner `flex-1` treatment as the Cashflow chart, so it fills its column height in the new 2-col row.
- Added `OutliersSkeleton` for loading state consistency.
- No click-throughs on rows yet (would need URL-param filters on `/transactions`, a separate feature). Filed in the issue's Out-of-Scope.

## Test plan

- [x] `tsc`, `lint`, `build` clean
- [x] 7/7 Playwright smoke tests pass
- [ ] Manual: on your real data, trend-breakers should populate for any category where this month's spend is ≥1.5× the 6-mo median. Largest-this-month populates immediately since it only needs current-period data.
- [ ] Manual: switch the period selector and confirm Outliers updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)